### PR TITLE
update bot to update posts instead of making a new post every time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,16 +365,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df097e3f506bec0e1a24f06bb3c962c228f36671de841ff579cb99f371772634"
 dependencies = [
  "futures 0.3.5",
- "rustls 0.18.0",
+ "rustls 0.18.1",
  "webpki",
  "webpki-roots 0.19.0",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.37"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caae68055714ff28740f310927e04f2eba76ff580b16fb18ed90073ee71646f7"
+checksum = "6e1a4a2f97ce50c9d0282c1468816208588441492b40d813b2e0419c22c05e7f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad97f54e1c9030ad57fae2f5e3791447f48bb225ab20f9d80515e7017d04378"
+checksum = "ea5800d29218fea137b0880387e5948694a23c93fcdde157006966693a865c7c"
 dependencies = [
  "async-channel",
  "atomic-waker",
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
+checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
 
 [[package]]
 name = "cfg-if"
@@ -1279,9 +1279,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
+checksum = "766d0e77a2c1502169d4a93ff3b8c15a71fd946cd0126309752104e5f3c46d94"
 dependencies = [
  "cfg-if",
  "crc32fast",
@@ -2054,7 +2054,7 @@ dependencies = [
  "futures-util",
  "hyper 0.13.7",
  "log",
- "rustls 0.18.0",
+ "rustls 0.18.1",
  "rustls-native-certs",
  "tokio 0.2.22",
  "tokio-rustls",
@@ -3033,7 +3033,7 @@ dependencies = [
  "libp2p-core",
  "log",
  "quicksink",
- "rustls 0.18.0",
+ "rustls 0.18.1",
  "rw-stream-sink",
  "soketto 0.4.1",
  "url 2.1.1",
@@ -3072,12 +3072,11 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.0.26"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db996576fae3289da8c9dd995645609c48b7fb7632d272dbd4dce014c090b71"
+checksum = "af67924b8dd885cccea261866c8ce5b74d239d272e154053ff927dae839f5ae9"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3560,9 +3559,9 @@ checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "octocrab"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3ac5571f6f610e3b58713bbeaa9ddb5532e89ab3467165b91d7ecb258c275"
+checksum = "a315f443b7b54de70cf158955bd7a29896a3d8d9a0d2c9c006194401a2e05257"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3581,11 +3580,11 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 dependencies = [
- "parking_lot 0.10.2",
+ "parking_lot 0.11.0",
 ]
 
 [[package]]
@@ -4148,9 +4147,9 @@ checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
 
 [[package]]
 name = "polling"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8a3045854c4a59af6d38cf7e57f0fe2cca449dc1b94dbfffbe96e0220928a2"
+checksum = "9e09dffb745feffca5be3dea51c02b7b368c4597ab0219a82acaf9799ab3e0d1"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4863,9 +4862,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac94b333ee2aac3284c5b8a1b7fb4dd11cba88c244e3fe33cdbd047af0eb693"
+checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
 dependencies = [
  "base64 0.12.3",
  "log",
@@ -4881,7 +4880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629d439a7672da82dd955498445e496ee2096fe2117b9f796558a43fdb9e59b8"
 dependencies = [
  "openssl-probe",
- "rustls 0.18.0",
+ "rustls 0.18.1",
  "schannel",
  "security-framework 1.0.0",
 ]
@@ -5693,27 +5692,10 @@ dependencies = [
 [[package]]
 name = "schnorrkel"
 version = "0.9.1"
-source = "git+https://github.com/w3f/schnorrkel#fa76d8becb45c60a9a7872a9a80f6e0597017356"
-dependencies = [
- "aead 0.2.0",
- "arrayref",
- "arrayvec 0.5.1",
- "curve25519-dalek",
- "getrandom",
- "merlin",
- "rand 0.7.3",
- "rand_core 0.5.1",
- "sha2 0.8.2",
- "subtle 2.2.3",
- "zeroize",
-]
-
-[[package]]
-name = "schnorrkel"
-version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021b403afe70d81eea68f6ea12f6b3c9588e5d536a94c3bf80f15e7faa267862"
 dependencies = [
+ "aead 0.2.0",
  "arrayref",
  "arrayvec 0.5.1",
  "curve25519-dalek",
@@ -6331,7 +6313,7 @@ dependencies = [
  "primitive-types",
  "rand 0.7.3",
  "regex",
- "schnorrkel 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel",
  "secrecy 0.6.0",
  "serde",
  "sha2 0.8.2",
@@ -6841,7 +6823,7 @@ checksum = "c004e8166d6e0aa3a9d5fa673e5b7098ff25f930de1013a21341988151e681bb"
 dependencies = [
  "hmac",
  "pbkdf2",
- "schnorrkel 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel",
  "sha2 0.8.2",
 ]
 
@@ -6949,7 +6931,7 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 [[package]]
 name = "sunshine-bounty"
 version = "0.2.1"
-source = "git+https://github.com/sunshine-protocol/sunshine-bounty#8b61a6d6097466af2347bbe605069df339ee2d31"
+source = "git+https://github.com/sunshine-protocol/sunshine-bounty#14ee55294b73a99a7ef0664fae0a02b15a342172"
 dependencies = [
  "clear_on_drop",
  "frame-support",
@@ -6963,7 +6945,7 @@ dependencies = [
 [[package]]
 name = "sunshine-bounty-client"
 version = "0.2.0"
-source = "git+https://github.com/sunshine-protocol/sunshine-bounty#8b61a6d6097466af2347bbe605069df339ee2d31"
+source = "git+https://github.com/sunshine-protocol/sunshine-bounty#14ee55294b73a99a7ef0664fae0a02b15a342172"
 dependencies = [
  "async-std",
  "frame-support",
@@ -6983,8 +6965,10 @@ dependencies = [
 [[package]]
 name = "sunshine-bounty-gbot"
 version = "0.0.1"
-source = "git+https://github.com/sunshine-protocol/sunshine-bounty#8b61a6d6097466af2347bbe605069df339ee2d31"
+source = "git+https://github.com/sunshine-protocol/sunshine-bounty#14ee55294b73a99a7ef0664fae0a02b15a342172"
 dependencies = [
+ "chrono",
+ "lazy_static",
  "octocrab",
  "thiserror",
 ]
@@ -6992,7 +6976,7 @@ dependencies = [
 [[package]]
 name = "sunshine-bounty-utils"
 version = "0.2.0"
-source = "git+https://github.com/sunshine-protocol/sunshine-bounty#8b61a6d6097466af2347bbe605069df339ee2d31"
+source = "git+https://github.com/sunshine-protocol/sunshine-bounty#14ee55294b73a99a7ef0664fae0a02b15a342172"
 dependencies = [
  "clear_on_drop",
  "derive-new",
@@ -7007,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "sunshine-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/sunshine-protocol/sunshine-core#c0ebde51041ba66bb0a4ad14daf67d2f7e8f3834"
+source = "git+https://github.com/sunshine-protocol/sunshine-core#9c0212f5d167519fe6d03cdb1a8a8415eee3503f"
 dependencies = [
  "async-std",
  "clap 3.0.0-beta.1",
@@ -7020,7 +7004,7 @@ dependencies = [
 [[package]]
 name = "sunshine-client-utils"
 version = "0.1.0"
-source = "git+https://github.com/sunshine-protocol/sunshine-core#c0ebde51041ba66bb0a4ad14daf67d2f7e8f3834"
+source = "git+https://github.com/sunshine-protocol/sunshine-core#9c0212f5d167519fe6d03cdb1a8a8415eee3503f"
 dependencies = [
  "anyhow",
  "async-std",
@@ -7045,7 +7029,7 @@ dependencies = [
 [[package]]
 name = "sunshine-codec"
 version = "0.1.0"
-source = "git+https://github.com/sunshine-protocol/sunshine-core#c0ebde51041ba66bb0a4ad14daf67d2f7e8f3834"
+source = "git+https://github.com/sunshine-protocol/sunshine-core#9c0212f5d167519fe6d03cdb1a8a8415eee3503f"
 dependencies = [
  "anyhow",
  "hash-db",
@@ -7057,7 +7041,7 @@ dependencies = [
 [[package]]
 name = "sunshine-crypto"
 version = "0.1.0"
-source = "git+https://github.com/sunshine-protocol/sunshine-core#c0ebde51041ba66bb0a4ad14daf67d2f7e8f3834"
+source = "git+https://github.com/sunshine-protocol/sunshine-core#9c0212f5d167519fe6d03cdb1a8a8415eee3503f"
 dependencies = [
  "aead 0.2.0",
  "anyhow",
@@ -7072,7 +7056,7 @@ dependencies = [
  "hash256-std-hasher",
  "parity-scale-codec",
  "rand 0.7.3",
- "schnorrkel 0.9.1 (git+https://github.com/w3f/schnorrkel)",
+ "schnorrkel",
  "secrecy 0.7.0",
  "sha2 0.9.1",
  "sp-core",
@@ -7088,7 +7072,7 @@ dependencies = [
 [[package]]
 name = "sunshine-faucet-client"
 version = "0.2.0"
-source = "git+https://github.com/sunshine-protocol/sunshine-identity#73795b06d34b5082ec298a5a726107d87c1dfd91"
+source = "git+https://github.com/sunshine-protocol/sunshine-identity#0a71a62a2c77897edca4d4848e2b92eb57d13a64"
 dependencies = [
  "parity-scale-codec",
  "substrate-subxt",
@@ -7099,7 +7083,7 @@ dependencies = [
 [[package]]
 name = "sunshine-faucet-pallet"
 version = "0.2.0"
-source = "git+https://github.com/sunshine-protocol/sunshine-identity#73795b06d34b5082ec298a5a726107d87c1dfd91"
+source = "git+https://github.com/sunshine-protocol/sunshine-identity#0a71a62a2c77897edca4d4848e2b92eb57d13a64"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7113,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "sunshine-identity-client"
 version = "0.2.3"
-source = "git+https://github.com/sunshine-protocol/sunshine-identity#73795b06d34b5082ec298a5a726107d87c1dfd91"
+source = "git+https://github.com/sunshine-protocol/sunshine-identity#0a71a62a2c77897edca4d4848e2b92eb57d13a64"
 dependencies = [
  "async-std",
  "frame-support",
@@ -7132,7 +7116,7 @@ dependencies = [
 [[package]]
 name = "sunshine-identity-pallet"
 version = "0.2.0"
-source = "git+https://github.com/sunshine-protocol/sunshine-identity#73795b06d34b5082ec298a5a726107d87c1dfd91"
+source = "git+https://github.com/sunshine-protocol/sunshine-identity#0a71a62a2c77897edca4d4848e2b92eb57d13a64"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7146,7 +7130,7 @@ dependencies = [
 [[package]]
 name = "sunshine-keystore"
 version = "0.1.0"
-source = "git+https://github.com/sunshine-protocol/sunshine-core#c0ebde51041ba66bb0a4ad14daf67d2f7e8f3834"
+source = "git+https://github.com/sunshine-protocol/sunshine-core#9c0212f5d167519fe6d03cdb1a8a8415eee3503f"
 dependencies = [
  "anyhow",
  "async-std",
@@ -7161,7 +7145,7 @@ dependencies = [
 [[package]]
 name = "sunshine-pallet-utils"
 version = "0.1.0"
-source = "git+https://github.com/sunshine-protocol/sunshine-core#c0ebde51041ba66bb0a4ad14daf67d2f7e8f3834"
+source = "git+https://github.com/sunshine-protocol/sunshine-core#9c0212f5d167519fe6d03cdb1a8a8415eee3503f"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -7533,7 +7517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "228139ddd4fea3fa345a29233009635235833e52807af7ea6448ead03890d6a9"
 dependencies = [
  "futures-core",
- "rustls 0.18.0",
+ "rustls 0.18.1",
  "tokio 0.2.22",
  "webpki",
 ]
@@ -7697,9 +7681,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe233f4227389ab7df5b32649239da7ebe0b281824b4e84b342d04d3fd8c25e"
+checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -7876,7 +7860,7 @@ dependencies = [
  "chunked_transfer",
  "lazy_static",
  "qstring",
- "rustls 0.18.0",
+ "rustls 0.18.1",
  "serde",
  "serde_json",
  "url 2.1.1",

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -86,9 +86,9 @@ impl Identity for Runtime {
 impl Bounty for Runtime {
     type IpfsReference = CidBytes;
     type BountyId = u64;
-    type BountyPost = BountyBody;
+    type BountyPost = GithubIssue;
     type SubmissionId = u64;
-    type BountySubmission = BountyBody;
+    type BountySubmission = GithubIssue;
 }
 
 impl substrate_subxt::Runtime for Runtime {
@@ -98,7 +98,7 @@ impl substrate_subxt::Runtime for Runtime {
 
 pub struct OffchainClient<S> {
     claims: IpldCache<S, Codec, Claim>,
-    bounties: IpldCache<S, Codec, BountyBody>,
+    bounties: IpldCache<S, Codec, GithubIssue>,
 }
 
 impl<S: Store> OffchainClient<S> {
@@ -111,7 +111,7 @@ impl<S: Store> OffchainClient<S> {
 }
 
 derive_cache!(OffchainClient, claims, Codec, Claim);
-derive_cache!(OffchainClient, bounties, Codec, BountyBody);
+derive_cache!(OffchainClient, bounties, Codec, GithubIssue);
 
 impl<S: Store> From<S> for OffchainClient<S> {
     fn from(store: S) -> Self {

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -5,8 +5,8 @@ use kb_client::{
         Result,
     },
     mock::AccountKeyring,
-    BountyBody,
     Client,
+    GithubIssue,
 };
 use sunshine_crypto::{
     keychain::TypedPair,
@@ -41,14 +41,14 @@ async fn main() -> Result<()> {
     bob_client
         .unlock(&SecretString::new("password".to_string()))
         .await?;
-    let bounty = BountyBody {
+    let bounty = GithubIssue {
         repo_owner: "sunshine-protocol".to_string(),
         repo_name: "sunshine-bounty".to_string(),
         issue_number: 160,
     };
     // (1) Alice posts a bounty!
     let _ = alice_client.post_bounty(bounty, 2000).await?;
-    let submission = BountyBody {
+    let submission = GithubIssue {
         repo_owner: "sunshine-protocol".to_string(),
         repo_name: "sunshine-bounty".to_string(),
         issue_number: 161,


### PR DESCRIPTION
* motivated by this comment https://github.com/sunshine-protocol/sunshine-bounty/issues/160#issuecomment-674386810
* contributed upstream to octocrab here https://github.com/XAMPPRocky/octocrab/pull/33
* issue examples https://github.com/sunshine-protocol/sunshine-bounty/issues/161 and https://github.com/sunshine-protocol/sunshine-bounty/issues/160

it was tested by following the directions on the README to run the chain + demo + bot locally s.t. the bot posted the last comments and edited those comments to update them in the issue examples linked above (and on the README)